### PR TITLE
feat: add compatibility check and health diagnostics compat feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,20 @@
 
 React components for Grafana Enterprise plugins
 
+## Compatibility
+
+There are situations when we require backwards compatibility with core Grafana and new features are only supported by newer versions.
+
+To handle this, we've introduced the `compatibility.ts` file which contains a list of features and the versions they support for better maintainability.
+
+### Considerations
+
+The way we are currently checking whether a feature is supported is by using the Grafana's [BuildInfo](https://grafana.com/docs/grafana/latest/packages_api/data/buildinfo/#version-property).
+
+However, there are cases when this version [may be masked](https://grafana.com/docs/grafana/latest/packages_api/data/buildinfo/#hideversion-property) from plugins.
+
+Only anonymous users (with read-only access) will be able to have their versions hidden, so this should be taken into consideration when deciding whether we should be adding a new feature to our compatibility list.
+
 ## Unreleased Components
 
 Sometimes we may want improvements/updates of `@grafana/ui` components but we don't want to update the minimum required versions of Grafana in our plugins and continue supporting older versions.

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "react-calendar": "^3.2.1",
     "react-dom": "^16.14.0",
     "react-use": "^15.3.4",
+    "semver": "^7.3.5",
     "typescript": "4.0.2"
   },
   "devDependencies": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,3 +6,4 @@
 export * from './components';
 export * from './unreleasedComponents';
 export * from './test/mocks';
+export * from './utils';

--- a/src/test/mocks/TestDatasource.ts
+++ b/src/test/mocks/TestDatasource.ts
@@ -1,0 +1,21 @@
+import { HealthCheckResult, HealthStatus } from "@grafana/runtime"
+import { Chance } from "chance"
+import { HealthCheckError, HealthCheckResultDetails, TestDatasourceReturn } from "../../utils/testDatasource"
+
+export const mockTestDatasourceReturn = (): TestDatasourceReturn => {
+  return Chance().pickone([mockHealthCheckResult(), mockHealthCheckResultError()])
+}
+
+export const mockHealthCheckResult = (): HealthCheckResult => ({
+  status: Chance().pickone(Object.values(HealthStatus)),
+  message: Chance().sentence(),
+  details: mockHealthCheckDetails()
+})
+
+export const mockHealthCheckDetails = (): HealthCheckResultDetails => ({
+  message: Chance().sentence(),
+  verboseMessage: Chance().sentence()
+})
+
+export const mockHealthCheckResultError = (details?: HealthCheckResultDetails): HealthCheckError =>
+  new HealthCheckError(Chance().sentence(), details || mockHealthCheckDetails())

--- a/src/utils/compatFeatures.test.ts
+++ b/src/utils/compatFeatures.test.ts
@@ -11,18 +11,18 @@ describe("healthDiagnosticsErrorsCompat", () => {
 
     it("returns baseTestDatasource response that is a health check result", async () => {
       const expectedResponse = mockHealthCheckResult() 
-      const mockBaseTestDatasource = jest.fn().mockResolvedValue(expectedResponse)
+      const baseDatasource = jest.fn().mockResolvedValue(expectedResponse)
 
-      const response = await healthDiagnosticsErrorsCompat(mockBaseTestDatasource)
+      const response = await healthDiagnosticsErrorsCompat(baseDatasource)
 
       expect(response).toEqual(expectedResponse)
     })
 
     it("returns baseTestDatasource response that is a health check error", async () => {
       const expectedResponse = mockHealthCheckResultError()
-      const mockBaseTestDatasource = jest.fn().mockRejectedValue(expectedResponse)
+      const baseTestDatasource = jest.fn().mockRejectedValue(expectedResponse)
 
-      const response = healthDiagnosticsErrorsCompat(mockBaseTestDatasource)
+      const response = healthDiagnosticsErrorsCompat(baseTestDatasource)
 
       await expect(response).rejects.toThrow(expectedResponse)
     })

--- a/src/utils/compatFeatures.test.ts
+++ b/src/utils/compatFeatures.test.ts
@@ -1,0 +1,54 @@
+import * as compat from "./compatibility"
+import { mockHealthCheckResult, mockHealthCheckResultError } from "../test/mocks/TestDatasource"
+import * as testDatasourceOverride from "./testDatasource"
+import { healthDiagnosticsErrorsCompat } from "./compatFeatures"
+
+describe("healthDiagnosticsErrorsCompat", () => {
+  describe("is compatible", () => {
+    beforeEach(() => {
+      jest.spyOn(compat, "hasCapability").mockReturnValue(true)
+    })
+
+    it("returns baseTestDatasource response that is a health check result", async () => {
+      const expectedResponse = mockHealthCheckResult() 
+      const mockBaseTestDatasource = jest.fn().mockResolvedValue(expectedResponse)
+
+      const response = await healthDiagnosticsErrorsCompat(mockBaseTestDatasource)
+
+      expect(response).toEqual(expectedResponse)
+    })
+
+    it("returns baseTestDatasource response that is a health check error", async () => {
+      const expectedResponse = mockHealthCheckResultError()
+      const mockBaseTestDatasource = jest.fn().mockRejectedValue(expectedResponse)
+
+      const response = healthDiagnosticsErrorsCompat(mockBaseTestDatasource)
+
+      await expect(response).rejects.toThrow(expectedResponse)
+    })
+  })
+
+  describe("is not compatible", () => {
+    beforeEach(() => {
+      jest.spyOn(compat, "hasCapability").mockReturnValue(false)
+    })
+
+    it("returns override testDatasource response that is a health check result", async () => {
+      const expectedResponse = mockHealthCheckResult() 
+      jest.spyOn(testDatasourceOverride, "testDatasource").mockResolvedValue(expectedResponse)
+
+      const call = await healthDiagnosticsErrorsCompat(jest.fn())
+
+      expect(call).toEqual(expectedResponse)
+    })
+
+    it("returns override testDatasource response that is a health check error", async () => {
+      const expectedResponse = mockHealthCheckResultError()
+      jest.spyOn(testDatasourceOverride, "testDatasource").mockRejectedValue(expectedResponse)
+
+      const call = healthDiagnosticsErrorsCompat(jest.fn())
+
+      await expect(call).rejects.toThrow(expectedResponse)
+    })
+  })
+})

--- a/src/utils/compatFeatures.test.ts
+++ b/src/utils/compatFeatures.test.ts
@@ -6,7 +6,7 @@ import { healthDiagnosticsErrorsCompat } from "./compatFeatures"
 describe("healthDiagnosticsErrorsCompat", () => {
   describe("is compatible", () => {
     beforeEach(() => {
-      jest.spyOn(compat, "hasCapability").mockReturnValue(true)
+      jest.spyOn(compat, "hasCompatibility").mockReturnValue(true)
     })
 
     it("returns baseTestDatasource response that is a health check result", async () => {
@@ -30,7 +30,7 @@ describe("healthDiagnosticsErrorsCompat", () => {
 
   describe("is not compatible", () => {
     beforeEach(() => {
-      jest.spyOn(compat, "hasCapability").mockReturnValue(false)
+      jest.spyOn(compat, "hasCompatibility").mockReturnValue(false)
     })
 
     it("returns override testDatasource response that is a health check result", async () => {

--- a/src/utils/compatFeatures.ts
+++ b/src/utils/compatFeatures.ts
@@ -1,0 +1,16 @@
+import { hasCapability, CompatibilityFeature } from "./compatibility";
+import { BaseTestDatasource, testDatasource, TestDatasourceReturn } from "./testDatasource";
+
+/**
+ * Calls the override testDatasource function for backwards compatibility if needed.
+ *
+ * @param baseTestDatasource The original testDatasource function
+ * @returns The result in the expected format for the Grafana version
+ */
+export const healthDiagnosticsErrorsCompat = (baseTestDatasource: BaseTestDatasource): Promise<TestDatasourceReturn> => {
+  if (hasCapability(CompatibilityFeature.HEALTH_DIAGNOSTICS_ERRORS)) {
+    return baseTestDatasource()
+  }
+
+  return testDatasource(baseTestDatasource);
+};

--- a/src/utils/compatFeatures.ts
+++ b/src/utils/compatFeatures.ts
@@ -1,4 +1,4 @@
-import { hasCapability, CompatibilityFeature } from "./compatibility";
+import { hasCompatibility, CompatibilityFeature } from "./compatibility";
 import { BaseTestDatasource, testDatasource, TestDatasourceReturn } from "./testDatasource";
 
 /**
@@ -8,7 +8,7 @@ import { BaseTestDatasource, testDatasource, TestDatasourceReturn } from "./test
  * @returns The result in the expected format for the Grafana version
  */
 export const healthDiagnosticsErrorsCompat = (baseTestDatasource: BaseTestDatasource): Promise<TestDatasourceReturn> => {
-  if (hasCapability(CompatibilityFeature.HEALTH_DIAGNOSTICS_ERRORS)) {
+  if (hasCompatibility(CompatibilityFeature.HEALTH_DIAGNOSTICS_ERRORS)) {
     return baseTestDatasource()
   }
 

--- a/src/utils/compatibility.test.ts
+++ b/src/utils/compatibility.test.ts
@@ -1,24 +1,24 @@
-import { hasCapability, CompatibilityFeature } from "./compatibility"
+import { hasCompatibility, CompatibilityFeature } from "./compatibility"
 import semver from "semver";
 
-describe("hasCapability", () => {
+describe("hasCompatibility", () => {
   it("returns false with a feature that is not supported", () => {
     const numberOfFeatures = Object.values(CompatibilityFeature).length
 
     // use an out of range enum value
-    expect(hasCapability(numberOfFeatures)).toBeFalsy()
+    expect(hasCompatibility(numberOfFeatures)).toBeFalsy()
   })
 
   it("returns true for HEALTH_DIAGNOSTICS_ERROR if the version is supported", () => {
     jest.spyOn(semver, "gte").mockReturnValue(true)
 
-    expect(hasCapability(CompatibilityFeature.HEALTH_DIAGNOSTICS_ERRORS)).toBeTruthy()
+    expect(hasCompatibility(CompatibilityFeature.HEALTH_DIAGNOSTICS_ERRORS)).toBeTruthy()
   })
 
   it("returns false for HEALTH_DIAGNOSTICS_ERROR if the version is not supported", () => {
     jest.spyOn(semver, "gte").mockReturnValue(false)
 
-    expect(hasCapability(CompatibilityFeature.HEALTH_DIAGNOSTICS_ERRORS)).toBeFalsy()
+    expect(hasCompatibility(CompatibilityFeature.HEALTH_DIAGNOSTICS_ERRORS)).toBeFalsy()
   })
 })
 

--- a/src/utils/compatibility.test.ts
+++ b/src/utils/compatibility.test.ts
@@ -1,0 +1,24 @@
+import { hasCapability, CompatibilityFeature } from "./compatibility"
+import semver from "semver";
+
+describe("hasCapability", () => {
+  it("returns false with a feature that is not supported", () => {
+    const numberOfFeatures = Object.values(CompatibilityFeature).length
+
+    // use an out of range enum value
+    expect(hasCapability(numberOfFeatures)).toBeFalsy()
+  })
+
+  it("returns true for HEALTH_DIAGNOSTICS_ERROR if the version is supported", () => {
+    jest.spyOn(semver, "gte").mockReturnValue(true)
+
+    expect(hasCapability(CompatibilityFeature.HEALTH_DIAGNOSTICS_ERRORS)).toBeTruthy()
+  })
+
+  it("returns false for HEALTH_DIAGNOSTICS_ERROR if the version is not supported", () => {
+    jest.spyOn(semver, "gte").mockReturnValue(false)
+
+    expect(hasCapability(CompatibilityFeature.HEALTH_DIAGNOSTICS_ERRORS)).toBeFalsy()
+  })
+})
+

--- a/src/utils/compatibility.ts
+++ b/src/utils/compatibility.ts
@@ -1,0 +1,40 @@
+import { config } from "@grafana/runtime";
+import { gte } from "semver";
+import { testDatasource, BaseTestDatasource } from "./testDatasource";
+
+enum CompatibilityFeature {
+  HEALTH_DIAGNOSTICS_ERRORS
+}
+
+/**
+ * Checks if the currently running version of Grafana supports the feature.
+ * 
+ * Enables graceful degradation for earlier versions that don't support a given capability.
+ *
+ * @param feature The feature that requires backwards compatibility
+ * @returns True if the Grafana version running can support the feature, otherwise false
+ */
+ const hasCapability = (feature: CompatibilityFeature): boolean => {
+  const version = config.buildInfo.version;
+
+  switch (feature) {
+    case CompatibilityFeature.HEALTH_DIAGNOSTICS_ERRORS:
+      return gte(version, "8.0.0");
+    default:
+      return false;
+  }
+};
+
+/**
+ * Calls the override testDatasource function for backwards compatibility if needed.
+ *
+ * @param baseTestDatasource The original testDatasource function
+* @returns The result in the expected format for the Grafana version
+ */
+ export const healthDiagnosticsErrorsCompat = (baseTestDatasource: BaseTestDatasource) => {
+  if (hasCapability(CompatibilityFeature.HEALTH_DIAGNOSTICS_ERRORS)) {
+    return baseTestDatasource()
+  }
+
+  return testDatasource(baseTestDatasource);
+};

--- a/src/utils/compatibility.ts
+++ b/src/utils/compatibility.ts
@@ -13,7 +13,7 @@ export enum CompatibilityFeature {
  * @param feature The feature that requires backwards compatibility
  * @returns True if the Grafana version running can support the feature, otherwise false
  */
- export const hasCapability = (feature: CompatibilityFeature): boolean => {
+ export const hasCompatibility = (feature: CompatibilityFeature): boolean => {
   const version = config.buildInfo.version;
 
   switch (feature) {

--- a/src/utils/compatibility.ts
+++ b/src/utils/compatibility.ts
@@ -1,8 +1,7 @@
 import { config } from "@grafana/runtime";
 import { gte } from "semver";
-import { testDatasource, BaseTestDatasource } from "./testDatasource";
 
-enum CompatibilityFeature {
+export enum CompatibilityFeature {
   HEALTH_DIAGNOSTICS_ERRORS
 }
 
@@ -14,7 +13,7 @@ enum CompatibilityFeature {
  * @param feature The feature that requires backwards compatibility
  * @returns True if the Grafana version running can support the feature, otherwise false
  */
- const hasCapability = (feature: CompatibilityFeature): boolean => {
+ export const hasCapability = (feature: CompatibilityFeature): boolean => {
   const version = config.buildInfo.version;
 
   switch (feature) {
@@ -23,18 +22,4 @@ enum CompatibilityFeature {
     default:
       return false;
   }
-};
-
-/**
- * Calls the override testDatasource function for backwards compatibility if needed.
- *
- * @param baseTestDatasource The original testDatasource function
-* @returns The result in the expected format for the Grafana version
- */
- export const healthDiagnosticsErrorsCompat = (baseTestDatasource: BaseTestDatasource) => {
-  if (hasCapability(CompatibilityFeature.HEALTH_DIAGNOSTICS_ERRORS)) {
-    return baseTestDatasource()
-  }
-
-  return testDatasource(baseTestDatasource);
 };

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,1 +1,2 @@
 export * from "./compatibility"
+export * from "./compatFeatures"

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,0 +1,1 @@
+export * from "./compatibility"

--- a/src/utils/testDatasource.test.ts
+++ b/src/utils/testDatasource.test.ts
@@ -1,0 +1,54 @@
+import { mockHealthCheckDetails, mockHealthCheckResult, mockHealthCheckResultError } from "../test/mocks/TestDatasource"
+import { testDatasource } from "./testDatasource"
+
+describe("testDatasource", () => {
+  it("returns baseTestDatasource response if it is a health check result", async () => {
+    const expectedResponse = mockHealthCheckResult()
+  
+    const baseDatasource = jest.fn().mockResolvedValue(expectedResponse)
+
+    expect(await testDatasource(baseDatasource)).toEqual(expectedResponse)
+  })
+
+  it("returns transformed error with error details verbose message if baseTestDatasource throws an error that has a details verbose message", async () => {
+    const mockError = mockHealthCheckResultError()
+  
+    const expectedError = {
+      ...mockError,
+      message: mockError.details?.verboseMessage
+    }
+
+    const baseDatasource = jest.fn().mockRejectedValue(mockError)
+
+    const call = testDatasource(baseDatasource)
+
+    await expect(call).rejects.toThrow(expectedError)
+  })
+
+  it("returns transformed error with error details message if baseTestDatasource throws an error that does not have a details verbose message", async () => {
+    const mockDetails = mockHealthCheckDetails()
+    delete mockDetails?.verboseMessage
+    const mockError = mockHealthCheckResultError(mockDetails)
+  
+    const expectedError = {
+      ...mockError,
+      message: mockDetails?.message
+    }
+
+    const baseDatasource = jest.fn().mockRejectedValue(mockError)
+
+    const call = testDatasource(baseDatasource)
+
+    await expect(call).rejects.toThrow(expectedError)
+  })
+
+  it("returns transformed error with error message if baseTestDatasource throws an error that does not have a details verbose message or details message", async () => {  
+    const mockError = mockHealthCheckResultError({})
+  
+    const baseDatasource = jest.fn().mockRejectedValue(mockError)
+
+    const call = testDatasource(baseDatasource)
+
+    await expect(call).rejects.toThrow(mockError)
+  })
+})

--- a/src/utils/testDatasource.ts
+++ b/src/utils/testDatasource.ts
@@ -1,0 +1,26 @@
+import { HealthCheckResult } from '@grafana/runtime';
+
+export type BaseTestDatasource = () => Promise<Partial<HealthCheckResult> | Error>
+
+/**
+ * Override function for testDatasource in Grafana for the health check
+ * 
+ * There is a new error format that is introduced in Grafana 8 which is not backwards compatible by default
+ * 
+ * This transforms the health check result into the old format if Grafana <8 is being used
+ *
+ * @param baseTestDatasource The original testDatasource function
+ * @returns Either the health check result if the health check was successful or an error that is handled later by Grafana
+ */
+export const testDatasource = async (baseTestDatasource: BaseTestDatasource) => {
+  // the backwards compatibility only affects the health check error messages
+  // so only transform the error we give to Grafana
+  try {
+    const response = await baseTestDatasource()
+    return response
+  }
+  catch (ex) {
+    // the priority order of the error message we want returned in the older format
+    throw new Error(ex.details?.verboseMessage ?? ex.details?.message ?? ex.message)
+  }
+}

--- a/src/utils/testDatasource.ts
+++ b/src/utils/testDatasource.ts
@@ -25,15 +25,10 @@ export type BaseTestDatasource = () => Promise<TestDatasourceReturn>
  * @param baseTestDatasource The original testDatasource function
  * @returns Either the health check result if the health check was successful or an error that is handled later by Grafana
  */
-export const testDatasource = async (baseTestDatasource: BaseTestDatasource): Promise<TestDatasourceReturn> => {
-  // the backwards compatibility only affects the health check error messages
-  // so only transform the error we give to Grafana
-  try {
-    const response = await baseTestDatasource()
-    return response
-  }
-  catch (ex) {
-    // the priority order of the error message we want returned in the older format
-    throw new Error(ex.details?.verboseMessage ?? ex.details?.message ?? ex.message)
-  }
-}
+export const testDatasource = (baseTestDatasource: BaseTestDatasource): Promise<TestDatasourceReturn> => 
+  baseTestDatasource()
+    // the backwards compatibility only affects the health check error messages
+    // so only transform the error we give to Grafana
+    .catch(ex => {
+      throw new Error(ex.details?.verboseMessage ?? ex.details?.message ?? ex.message)
+    })

--- a/src/utils/testDatasource.ts
+++ b/src/utils/testDatasource.ts
@@ -1,6 +1,19 @@
 import { HealthCheckResult } from '@grafana/runtime';
 
-export type BaseTestDatasource = () => Promise<Partial<HealthCheckResult> | Error>
+// These are from core Grafana - they are not exported
+export type HealthCheckResultDetails = Record<string, any> | undefined
+export class HealthCheckError extends Error {
+  details: HealthCheckResultDetails;
+
+  constructor(message: string, details: HealthCheckResultDetails) {
+    super(message);
+    this.details = details;
+    this.name = 'HealthCheckError';
+  }
+}
+
+export type TestDatasourceReturn = Partial<HealthCheckResult> | Error
+export type BaseTestDatasource = () => Promise<TestDatasourceReturn>
 
 /**
  * Override function for testDatasource in Grafana for the health check
@@ -12,7 +25,7 @@ export type BaseTestDatasource = () => Promise<Partial<HealthCheckResult> | Erro
  * @param baseTestDatasource The original testDatasource function
  * @returns Either the health check result if the health check was successful or an error that is handled later by Grafana
  */
-export const testDatasource = async (baseTestDatasource: BaseTestDatasource) => {
+export const testDatasource = async (baseTestDatasource: BaseTestDatasource): Promise<TestDatasourceReturn> => {
   // the backwards compatibility only affects the health check error messages
   // so only transform the error we give to Grafana
   try {

--- a/src/utils/testDatasource.ts
+++ b/src/utils/testDatasource.ts
@@ -27,8 +27,9 @@ export type BaseTestDatasource = () => Promise<TestDatasourceReturn>
  */
 export const testDatasource = (baseTestDatasource: BaseTestDatasource): Promise<TestDatasourceReturn> => 
   baseTestDatasource()
-    // the backwards compatibility only affects the health check error messages
-    // so only transform the error we give to Grafana
-    .catch(ex => {
-      throw new Error(ex.details?.verboseMessage ?? ex.details?.message ?? ex.message)
-    })
+  // the backwards compatibility only affects the health check error messages
+  // so only transform the error we give to Grafana
+  .catch(ex => {
+    throw new Error(ex.details?.verboseMessage ?? ex.details?.message ?? ex.message)
+  })
+  

--- a/yarn.lock
+++ b/yarn.lock
@@ -14257,6 +14257,13 @@ semver@^6.0.0, semver@^6.3.0:
   resolved "https://registry.yarnpkg.com/semver/-/semver-6.3.0.tgz#ee0a64c8af5e8ceea67687b133761e1becbd1d3d"
   integrity sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==
 
+semver@^7.3.5:
+  version "7.3.5"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-7.3.5.tgz#0b621c879348d8998e4b0e4be94b3f12e6018ef7"
+  integrity sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==
+  dependencies:
+    lru-cache "^6.0.0"
+
 send@0.17.1:
   version "0.17.1"
   resolved "https://registry.yarnpkg.com/send/-/send-0.17.1.tgz#c1d8b059f7900f7466dd4938bdc44e11ddb376c8"


### PR DESCRIPTION
Issue: https://github.com/grafana/ui-enterprise/issues/38 - please read, there is a lot of context and screenshots which may help 🙏 

Supports the old format of error messages for users running Grafana <8, even when we have a new backend response coming from the plugin (for Grafana 8+).

Overriding the `testDatasource` function allows us to keep the new backend response and new core Grafana UI as it is for the new changes, but allow support for transforming what we send back from our plugin to core Grafana. This should improve maintainability.

Takes inspriration from https://github.com/marcusolsson/grafana-plugin-support/blob/c3f0272005d2e68142a756dbd85ad2df1ccbb962/src/utils/capability.ts

The addition of the new `compatibility.ts` and `compatFeatures.ts` files should also help us with similar issues in the future for easier maintainability for knowing what compatibility issues we have. These can also be shared across all our plugins, rather than requiring copypasta in each individual plugin.

**Usage:**

From the plugin's `datasource.ts` file:

```ts
import { healthDiagnosticsErrorsCompat } from 'ui-enterprise';

async testDatasource() {
    return healthDiagnosticsErrorsCompat(super.testDatasource.bind(this))
}
```

**Before**

Grafana <8:

With no support for backwards compatibility, users would see an error message that is not useful:

![image](https://user-images.githubusercontent.com/36230812/116699694-cab98100-a9bd-11eb-96ae-be68c000d9bb.png)

Grafana 8+:

![image](https://user-images.githubusercontent.com/36230812/116699682-c4c3a000-a9bd-11eb-870f-93006470d281.png)

**After**

Grafana <8:

They can now see the same old format and the new changes do not affect it:

![image](https://user-images.githubusercontent.com/36230812/116699741-d9079d00-a9bd-11eb-8353-98ade97f64d9.png)

Grafana 8+:

![image](https://user-images.githubusercontent.com/36230812/116699678-c3927300-a9bd-11eb-998f-c7803f4c8ebd.png)
