### PR TITLE
chore: add support for feature toggle for health diagnostics

### DIFF
--- a/src/utils/compatFeatures.test.ts
+++ b/src/utils/compatFeatures.test.ts
@@ -4,27 +4,68 @@ import * as testDatasourceOverride from "./testDatasource"
 import { healthDiagnosticsErrorsCompat } from "./compatFeatures"
 
 describe("healthDiagnosticsErrorsCompat", () => {
+  afterEach(() => {
+    jest.restoreAllMocks()
+  })
+
   describe("is compatible", () => {
     beforeEach(() => {
       jest.spyOn(compat, "hasCompatibility").mockReturnValue(true)
+
     })
 
-    it("returns baseTestDatasource response that is a health check result", async () => {
-      const expectedResponse = mockHealthCheckResult() 
+    it("returns baseTestDatasource response that is a health check result if toggle is true", async () => {
+      const expectedResponse = mockHealthCheckResult()
       const baseDatasource = jest.fn().mockResolvedValue(expectedResponse)
-
-      const response = await healthDiagnosticsErrorsCompat(baseDatasource)
-
+  
+      const response = await healthDiagnosticsErrorsCompat(baseDatasource, true)
+  
       expect(response).toEqual(expectedResponse)
     })
 
-    it("returns baseTestDatasource response that is a health check error", async () => {
+    it("returns override testDatasource response that is a health check result if toggle is false", async () => {
+      const expectedResponse = mockHealthCheckResult()
+      jest.spyOn(testDatasourceOverride, "testDatasource").mockResolvedValue(expectedResponse)
+
+      const response = await healthDiagnosticsErrorsCompat(jest.fn(), false)
+  
+      expect(response).toEqual(expectedResponse)
+    })
+
+    it("returns override testDatasource response that is a health check result if toggle is not passed in", async () => {
+      const expectedResponse = mockHealthCheckResult()
+      jest.spyOn(testDatasourceOverride, "testDatasource").mockResolvedValue(expectedResponse)
+
+      const response = await healthDiagnosticsErrorsCompat(jest.fn())
+  
+      expect(response).toEqual(expectedResponse)
+    })
+
+    it("returns baseTestDatasource response that is a health check error if toggle is true", async () => {
       const expectedResponse = mockHealthCheckResultError()
-      const baseTestDatasource = jest.fn().mockRejectedValue(expectedResponse)
+      const baseDatasource = jest.fn().mockRejectedValue(expectedResponse)
 
-      const response = healthDiagnosticsErrorsCompat(baseTestDatasource)
+      const call = healthDiagnosticsErrorsCompat(baseDatasource, true)
 
-      await expect(response).rejects.toThrow(expectedResponse)
+      await expect(call).rejects.toThrow(expectedResponse)
+    })
+
+    it("returns override testDatasource response that is a health check error if toggle is false", async () => {
+      const expectedResponse = mockHealthCheckResultError()
+      jest.spyOn(testDatasourceOverride, "testDatasource").mockRejectedValue(expectedResponse)
+
+      const call = healthDiagnosticsErrorsCompat(jest.fn(), false)
+
+      await expect(call).rejects.toThrow(expectedResponse)
+    })
+
+    it("returns override testDatasource response that is a health check error if toggle is not passed in", async () => {
+      const expectedResponse = mockHealthCheckResultError()
+      jest.spyOn(testDatasourceOverride, "testDatasource").mockRejectedValue(expectedResponse)
+
+      const call = healthDiagnosticsErrorsCompat(jest.fn())
+
+      await expect(call).rejects.toThrow(expectedResponse)
     })
   })
 
@@ -33,16 +74,52 @@ describe("healthDiagnosticsErrorsCompat", () => {
       jest.spyOn(compat, "hasCompatibility").mockReturnValue(false)
     })
 
-    it("returns override testDatasource response that is a health check result", async () => {
-      const expectedResponse = mockHealthCheckResult() 
+    it("returns override testDatasource response that is a health check result if toggle is true", async () => {
+      const expectedResponse = mockHealthCheckResult()
       jest.spyOn(testDatasourceOverride, "testDatasource").mockResolvedValue(expectedResponse)
 
-      const call = await healthDiagnosticsErrorsCompat(jest.fn())
-
-      expect(call).toEqual(expectedResponse)
+      const response = await healthDiagnosticsErrorsCompat(jest.fn(), true)
+  
+      expect(response).toEqual(expectedResponse)
     })
 
-    it("returns override testDatasource response that is a health check error", async () => {
+    it("returns base testDatasource response that is a health check result if toggle is false", async () => {
+      const expectedResponse = mockHealthCheckResult()
+      const baseDatasource = jest.fn().mockResolvedValue(expectedResponse)
+  
+      const response = await healthDiagnosticsErrorsCompat(baseDatasource, false)
+  
+      expect(response).toEqual(expectedResponse)
+    })
+
+    it("returns base testDatasource response that is a health check result if toggle is not passed in", async () => {
+      const expectedResponse = mockHealthCheckResult()
+      const baseDatasource = jest.fn().mockResolvedValue(expectedResponse)
+  
+      const response = await healthDiagnosticsErrorsCompat(baseDatasource)
+  
+      expect(response).toEqual(expectedResponse)
+    })
+
+    it("returns override testDatasource response that is a health check error if toggle is true", async () => {
+      const expectedResponse = mockHealthCheckResultError()
+      jest.spyOn(testDatasourceOverride, "testDatasource").mockRejectedValue(expectedResponse)
+
+      const call = healthDiagnosticsErrorsCompat(jest.fn(), true)
+
+      await expect(call).rejects.toThrow(expectedResponse)
+    })
+
+    it("returns base testDatasource response that is a health check error if toggle is false", async () => {
+      const expectedResponse = mockHealthCheckResultError()
+      jest.spyOn(testDatasourceOverride, "testDatasource").mockRejectedValue(expectedResponse)
+
+      const call = healthDiagnosticsErrorsCompat(jest.fn(), false)
+
+      await expect(call).rejects.toThrow(expectedResponse)
+    })
+
+    it("returns base testDatasource response that is a health check error if toggle is not passed in", async () => {
       const expectedResponse = mockHealthCheckResultError()
       jest.spyOn(testDatasourceOverride, "testDatasource").mockRejectedValue(expectedResponse)
 

--- a/src/utils/compatFeatures.ts
+++ b/src/utils/compatFeatures.ts
@@ -7,8 +7,8 @@ import { BaseTestDatasource, testDatasource, TestDatasourceReturn } from "./test
  * @param baseTestDatasource The original testDatasource function
  * @returns The result in the expected format for the Grafana version
  */
-export const healthDiagnosticsErrorsCompat = (baseTestDatasource: BaseTestDatasource): Promise<TestDatasourceReturn> => {
-  if (hasCompatibility(CompatibilityFeature.HEALTH_DIAGNOSTICS_ERRORS)) {
+export const healthDiagnosticsErrorsCompat = (baseTestDatasource: BaseTestDatasource, toggle?: boolean): Promise<TestDatasourceReturn> => {
+  if (toggle && hasCompatibility(CompatibilityFeature.HEALTH_DIAGNOSTICS_ERRORS)) {
     return baseTestDatasource()
   }
 

--- a/src/utils/compatFeatures.ts
+++ b/src/utils/compatFeatures.ts
@@ -5,6 +5,7 @@ import { BaseTestDatasource, testDatasource, TestDatasourceReturn } from "./test
  * Calls the override testDatasource function for backwards compatibility if needed.
  *
  * @param baseTestDatasource The original testDatasource function
+ * @param toggle Accepts a feature toggle. Defaults to false so it is clear when we want this feature turned on.
  * @returns The result in the expected format for the Grafana version
  */
 export const healthDiagnosticsErrorsCompat = (baseTestDatasource: BaseTestDatasource, toggle?: boolean): Promise<TestDatasourceReturn> => {

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,2 +1,2 @@
 export * from "./compatibility"
-export * from "./compatFeatures"
+export * as compatFeatures from "./compatFeatures"

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,2 +1,3 @@
 export * from "./compatibility"
+export * from "./compatFeatures"
 export * as compatFeatures from "./compatFeatures"


### PR DESCRIPTION
Add support for toggling our `healthDiagnosticsErrorsCompat` return.

This is because for the new health diagnostic error messages, we are planning to beta release them first so we want them to be switched off by default.

Usage in our plugins:

```
import { healthDiagnosticsErrorsCompat } from 'ui-enterprise';
import toggles from './featureToggles';

async testDatasource() {
    return healthDiagnosticsErrorsCompat(super.testDatasource.bind(this), toggles.healthDiagnosticsErrors);
}
```