### PR TITLE
Reexporting InlineSwitch and  CertificationKey

### DIFF
--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -17,3 +17,4 @@ export {
 export * from './DataSourcePicker/DataSourcePicker';
 export * from './DataLinks';
 export * from './Cascader/Cascader';
+export { InlineSwitch, CertificationKey } from '@grafana/ui';


### PR DESCRIPTION
* Re-exporting InlineSwitch, CertificationKey from @grafana/ui package to support 7.2 in SAP HANA